### PR TITLE
Upgrade to node16 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
   json-results:
     description: The results as a JSON string
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'cpu'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
