### PR TITLE
Bump actions/checkout from v2 to v6

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run all
   get-dirty:
@@ -23,7 +23,7 @@ jobs:
       clean-bits: ${{ steps.dirty-bits.outputs.clean-bits }}
       dirty-bits: ${{ steps.dirty-bits.outputs.dirty-bits }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ./
         id: dirty-bits
         with:


### PR DESCRIPTION
Update the checkout action used in the build-test workflow to the
latest major version.
