### PR TITLE
Pin actions/checkout to a commit SHA

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: npm ci
       - run: npm run all
   get-dirty:
@@ -23,7 +23,7 @@ jobs:
       clean-bits: ${{ steps.dirty-bits.outputs.clean-bits }}
       dirty-bits: ${{ steps.dirty-bits.outputs.dirty-bits }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./
         id: dirty-bits
         with:


### PR DESCRIPTION
Use the immutable v6.1.0 commit instead of its mutable release tag.
